### PR TITLE
windows support

### DIFF
--- a/const.py
+++ b/const.py
@@ -4,7 +4,8 @@ from aqt import mw
 import os
 
 BASE_URL_DICTIONARIES = "https://api.github.com/repos/wooorm/dictionaries/contents"
-URL_BINARIES = "https://github.com/jankelemen/convert-dict-tool-from-chromium/archive/refs/heads/master.zip"
+URL_BINARIES = "https://github.com/jankelemen/convert-dict-tool-from-chromium/archive/refs/heads/master.zip"\
+    if os.name != 'nt' else 'https://github.com/jmbeach/convert_dict_windows/archive/refs/heads/main.zip'
 VERSION_DICTIONARIES = "2a5353f1617f00e606dc036cab1c37df94272ca0"
 URL_DICTIONARIES = lambda path: f"{BASE_URL_DICTIONARIES}/{path}?ref={VERSION_DICTIONARIES}"
 
@@ -14,7 +15,7 @@ USER_PATH = os.path.join(ADDON_PATH, "user_files")
 ENABLED_PATH = os.path.join(USER_PATH, "enabled.pck")
 USER_DICT_PATH = os.path.join(USER_PATH, "user_dics")
 BINS_PATH = os.path.join(ADDON_PATH, "convert_dict")
-BIN_PATH = os.path.join(ADDON_PATH, "convert_dict", "convert_dict")
+BIN_PATH = os.path.join(ADDON_PATH, "convert_dict",  "convert_dict" if os.name != 'nt' else "convert_dict.exe")
 PERSONAL_PATH = os.path.join(USER_PATH, "user_dics", "personal.txt")
 
 try:

--- a/manage.py
+++ b/manage.py
@@ -108,10 +108,11 @@ def checkConversionBinaries(*args):
 
 
 def compileBDIC(path, name, remove=False):
-    command = [BIN_PATH + " " + os.path.join(path, name)]
-    mode = os.stat(BIN_PATH).st_mode
-    mode |= (mode & 0o444) >> 2  # copy R bits to X
-    os.chmod(BIN_PATH, mode)
+    command = [BIN_PATH, os.path.join(path, name)]
+    if os.name != 'nt':
+        mode = os.stat(BIN_PATH).st_mode
+        mode |= (mode & 0o444) >> 2  # copy R bits to X
+        os.chmod(BIN_PATH, mode)
     res = subprocess.run(command, shell=True, capture_output=True, text=True)
     if remove:
         ex = [".dic", ".aff"]


### PR DESCRIPTION
If the user is on Windows, download alternate binaries from another repo.

I made this repo https://github.com/jmbeach/convert_dict_windows where I put the windows binaries for convert_dict. I followed instructions from [Chromium's windows instructions](https://chromium.googlesource.com/chromium/src/+/main/docs/windows_build_instructions.md) and [this medium article](https://mwichary.medium.com/fixing-a-chrome-dictionary-issue-bbd7c5314f01)

Thanks for your work on this addon!